### PR TITLE
Add a Semigroup instance for SrcLoc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /dist/
+dist-newstyle
+.ghc.environment.*

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,9 +28,12 @@ matrix:
     - env: CABALVER=1.24 GHCVER=8.0.2
       compiler: ": #GHC 8.0.2"
       addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.2], sources: [hvr-ghc]}}
-    - env: CABALVER=head GHCVER=8.2.1
+    - env: CABALVER=2.0 GHCVER=8.2.1
       compiler: ": #GHC 8.2.1"
-      addons: {apt: {packages: [cabal-install-head,ghc-8.2.1], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [cabal-install-2.0,ghc-8.2.1], sources: [hvr-ghc]}}
+    - compiler: ": #GHC 8.4.1"
+      env: CABALVER=2.2 GHCVER=8.4.1
+      addons: {apt: {packages: [cabal-install-2.2,ghc-8.4.1], sources: [hvr-ghc]}}
     - env: CABALVER=head GHCVER=head
       compiler: ": #GHC HEAD"
       addons: {apt: {packages: [cabal-install-head,ghc-head],  sources: [hvr-ghc]}}

--- a/srcloc.cabal
+++ b/srcloc.cabal
@@ -12,7 +12,8 @@ homepage:       https://github.com/mainland/srcloc
 category:       Data
 synopsis:       Data types for managing source code locations.
 description:    Data types for tracking, combining, and printing source code locations.
-tested-with:    GHC==7.4.2, GHC==7.6.3, GHC==7.8.3, GHC==7.10.3, GHC==8.0.2, GHC==8.2.1
+tested-with:    GHC==7.4.2, GHC==7.6.3, GHC==7.8.3, GHC==7.10.3, GHC==8.0.2,
+                GHC==8.2.1, GHC==8.4.1
 
 build-type:     Simple
 


### PR DESCRIPTION
In GHC 8.4 `Semigroup` is a superclass of `Monoid`.